### PR TITLE
Remove monitor-content per upstream

### DIFF
--- a/syntax/tmux.vim
+++ b/syntax/tmux.vim
@@ -222,7 +222,6 @@ syn keyword tmuxOptsSet
 	\ update-environment
 	\ visual-activity
 	\ visual-bell
-	\ visual-content
 	\ visual-silence
 	\ word-separators
 
@@ -243,7 +242,6 @@ syn keyword tmuxOptsSetw
 	\ mode-mouse
 	\ mode-style
 	\ monitor-activity
-	\ monitor-content
 	\ monitor-silence
 	\ other-pane-height
 	\ other-pane-width
@@ -253,7 +251,6 @@ syn keyword tmuxOptsSetw
 	\ utf8
 	\ window-status-activity-style
 	\ window-status-bell-style
-	\ window-status-content-style
 	\ window-status-current-format
 	\ window-status-current-style
 	\ window-status-format


### PR DESCRIPTION
monitor-content is gone from tmux 2.0, for over a year. Upstream has removed it from syntax file in https://github.com/tmux/tmux/commit/8abcea18a24dea24d6049fefa31c877133489092.